### PR TITLE
[TEMPORARY]: Disable github buttons and use regular links

### DIFF
--- a/public/technology/index.html
+++ b/public/technology/index.html
@@ -87,7 +87,7 @@
                   <p class="inner-content__body">
                     Counterfactual provides a simple client library, similar to Web3, that applications can use to construct and transmit messages to their counterparties using the off-chain protocol.
                   </p>
-                  <a class="github-button" href="https://specs.counterfactual.com" data-size="large" aria-label="View counterfactual/specs on GitHub">View on Github</a>
+                  <a target="_blank" href="https://specs.counterfactual.com" data-size="large" aria-label="View counterfactual/specs on GitHub">View on Github</a>
                 </div>
               </div>
 
@@ -98,7 +98,7 @@
                   <p class="inner-content__body">
                     Counterfactual defines a protocol for off chain applications that is maximally secure, flexible, and intuitive while remaining abstract enough to cover arbitrary blockchain transactions. At its core, the protocol is centered around a type of conditional transaction based on the outcome of an "<a href="https://specs.counterfactual.com/blob/master/01-contracts.md#appinstance">AppInstance</a>"; a state channel application. These applications can be installed, updated, and uninstalled within a state channel.
                   </p>
-                  <a class="github-button" href="https://specs.counterfactual.com" data-size="large" aria-label="View counterfactual/specs on GitHub">View on Github</a>
+                  <a target="_blank" href="https://specs.counterfactual.com" data-size="large" aria-label="View counterfactual/specs on GitHub">View on Github</a>
                 </div>
 
               </div>
@@ -110,7 +110,7 @@
                   <p class="inner-content__body">
                     All transactions that users sign while using the protocol are ultimately designed such that they could be placed on the blockchain in the case of a party being unresponsive or attempting to deviate from the protocol. Counterfactual implements the minimum functionality needed for dealing with state channels of abstract transactions by combining the best in class research from teams like <a href="https://l4.ventures">L4</a>, <a href="https://magmo.com">Magmo</a>, <a href="https://arxiv.org/abs/1702.05812">Sprites</a>, <a href="https://perun.network">Perun</a>, and many others into a single on-chain set of contracts.
                   </p>
-                  <a class="github-button" href="https://specs.counterfactual.com/blob/master/01-contracts.md" data-size="large" aria-label="View counterfactual/specs on GitHub">View on Github</a>
+                  <a target="_blank" href="https://specs.counterfactual.com/blob/master/01-contracts.md" data-size="large" aria-label="View counterfactual/specs on GitHub">View on Github</a>
                 </div>
 
               </div>
@@ -160,6 +160,6 @@
   <!-- End Wrapper -->
 
   <script src="/app.js" charset="utf-8"></script>
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
+  <!-- <script async defer src="https://buttons.github.io/buttons.js"></script> -->
 </body>
 </html>


### PR DESCRIPTION
@ebryn / @snario 

I've included this PR as a temporary fix for the github buttons that are breaking on the technology page.

When inspecting the element the href is being set as `#`. My hunch is that you **have** to adhere to one of the href conventions as listed here: https://github.com/ntkme/github-buttons#built-in-button-types

Following each of these seems to work just fine.
ie. `https://github.com/:user/:repo`

We're currently linking to: `https://specs.counterfactual.com`, which does not fit into this convention.

I see three potential paths moving forward:
1. Use one of the href options listed above for each instance
2. Manually embed the button to the html and link as we wish
3. Opt out of the branded buttons

Thoughts / preferences?